### PR TITLE
return cellDividerData only if it is not null

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -15,7 +15,7 @@ NSData *cellDividerData;
     BOOL hasShorts = ([description containsString:@"shorts_shelf.eml"] || [description containsString:@"shorts_video_cell.eml"] || [description containsString:@"6Shorts"]) && ![description containsString:@"history*"];
     BOOL hasShortsInHistory = [description containsString:@"compact_video.eml"] && [description containsString:@"youtube_shorts_"];
 
-    if (hasShorts || hasShortsInHistory) return cellDividerData;
+    if (hasShorts || hasShortsInHistory) return cellDividerData ?: %orig;
 
     return %orig;
 }

--- a/Tweak.x
+++ b/Tweak.x
@@ -15,7 +15,7 @@ NSData *cellDividerData;
     BOOL hasShorts = ([description containsString:@"shorts_shelf.eml"] || [description containsString:@"shorts_video_cell.eml"] || [description containsString:@"6Shorts"]) && ![description containsString:@"history*"];
     BOOL hasShortsInHistory = [description containsString:@"compact_video.eml"] && [description containsString:@"youtube_shorts_"];
 
-    if (hasShorts || hasShortsInHistory) return cellDividerData ?: %orig;
+    if ((hasShorts || hasShortsInHistory) && cellDividerData) return cellDividerData;
 
     return %orig;
 }


### PR DESCRIPTION
Mainly intended for the iPads since the shorts cells on iPad has big height and often added as the first object, which leads to return nil data and cell will have original height (blank space instead of cell divider)